### PR TITLE
Allow filter to be configured after aggregator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@
 /doc/
 /pkg/
 /spec/reports/
-/tmp/
+tmp/
 
 # rspec failure tracking
 .rspec_status

--- a/lib/attr/gather/aggregators/base.rb
+++ b/lib/attr/gather/aggregators/base.rb
@@ -9,7 +9,7 @@ module Attr
       # @!attribute [r] filter
       #   @return [Attr::Gather::Filters::Base] filter for the output data
       class Base
-        attr_reader :filter
+        attr_accessor :filter
 
         def initialize(**opts)
           @filter = opts.delete(:filter)

--- a/lib/attr/gather/workflow/callable.rb
+++ b/lib/attr/gather/workflow/callable.rb
@@ -71,7 +71,6 @@ module Attr
           return @aggregator if @aggregator
 
           @aggregator = self.class.aggregator
-          @aggregator ||= Aggregators.default
           @aggregator.filter ||= filter
 
           @aggregator

--- a/lib/attr/gather/workflow/callable.rb
+++ b/lib/attr/gather/workflow/callable.rb
@@ -68,7 +68,7 @@ module Attr
 
         # @api private
         def aggregator
-          return @aggregator if @aggregator
+          return @aggregator if defined?(@aggregator) && !@aggregator.nil?
 
           @aggregator = self.class.aggregator
           @aggregator.filter ||= filter

--- a/lib/attr/gather/workflow/callable.rb
+++ b/lib/attr/gather/workflow/callable.rb
@@ -68,7 +68,18 @@ module Attr
 
         # @api private
         def aggregator
-          self.class.aggregator
+          return @aggregator if @aggregator
+
+          @aggregator = self.class.instance_variable_get(:@aggregator)
+          @aggregator ||= Aggregators.default
+          @aggregator.filter ||= filter
+
+          @aggregator
+        end
+
+        # @api private
+        def filter
+          self.class.filter
         end
       end
     end

--- a/lib/attr/gather/workflow/callable.rb
+++ b/lib/attr/gather/workflow/callable.rb
@@ -70,7 +70,7 @@ module Attr
         def aggregator
           return @aggregator if @aggregator
 
-          @aggregator = self.class.instance_variable_get(:@aggregator)
+          @aggregator = self.class.aggregator
           @aggregator ||= Aggregators.default
           @aggregator.filter ||= filter
 

--- a/lib/attr/gather/workflow/dsl.rb
+++ b/lib/attr/gather/workflow/dsl.rb
@@ -84,8 +84,10 @@ module Attr
         # @param agg [#call] the aggregator to use
         #
         # @api public
-        def aggregator(agg, opts = EMPTY_HASH)
-          @aggregator = Aggregators.resolve(agg, filter: filter, **opts)
+        def aggregator(agg = nil, opts = EMPTY_HASH)
+          @aggregator = Aggregators.resolve(agg, filter: filter, **opts) if agg
+
+          @aggregator
         end
 
         # Defines a filter for filtering out invalid values

--- a/lib/attr/gather/workflow/dsl.rb
+++ b/lib/attr/gather/workflow/dsl.rb
@@ -87,7 +87,7 @@ module Attr
         def aggregator(agg = nil, opts = EMPTY_HASH)
           @aggregator = Aggregators.resolve(agg, filter: filter, **opts) if agg
 
-          @aggregator
+          @aggregator || Aggregators.default
         end
 
         # Defines a filter for filtering out invalid values

--- a/lib/attr/gather/workflow/dsl.rb
+++ b/lib/attr/gather/workflow/dsl.rb
@@ -85,9 +85,13 @@ module Attr
         #
         # @api public
         def aggregator(agg = nil, opts = EMPTY_HASH)
-          @aggregator = Aggregators.resolve(agg, filter: filter, **opts) if agg
+          if agg.nil? && !defined?(@aggregator)
+            @aggregator = Aggregators.default
+            return @aggregator
+          end
 
-          @aggregator || Aggregators.default
+          @aggregator = Aggregators.resolve(agg, filter: filter, **opts) if agg
+          @aggregator
         end
 
         # Defines a filter for filtering out invalid values

--- a/lib/attr/gather/workflow/dsl.rb
+++ b/lib/attr/gather/workflow/dsl.rb
@@ -84,14 +84,8 @@ module Attr
         # @param agg [#call] the aggregator to use
         #
         # @api public
-        def aggregator(agg = nil, opts = EMPTY_HASH)
-          if agg.nil? && !defined?(@aggregator)
-            @aggregator = Aggregators.default
-            return @aggregator
-          end
-
-          @aggregator = Aggregators.resolve(agg, filter: filter, **opts) if agg
-          @aggregator
+        def aggregator(agg, opts = EMPTY_HASH)
+          @aggregator = Aggregators.resolve(agg, filter: filter, **opts)
         end
 
         # Defines a filter for filtering out invalid values

--- a/spec/attr/gather/workflow_spec.rb
+++ b/spec/attr/gather/workflow_spec.rb
@@ -110,7 +110,6 @@ module Attr
         end
 
         it 'filters out bad values' do
-          user_workflow_class.aggregator(:deep_merge)
           workflow = user_workflow_class.new
           result = workflow.call({})
 


### PR DESCRIPTION
Currently, the filter is provided to the aggregator when the aggregator is defined on the workflow. This requires the filter to be configured prior to the aggregator. Also, when the default aggregator is used, the filter is not provided to it.

This PR modifies the `aggregator` method called by the workflow to return the aggregator configured with the filter.
 
This fixes #10 